### PR TITLE
Some fixes to pass CRAN checks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@ windows
 ^docs$
 ^pkgdown$
 ^codecov\.yml$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ README.html
 windows
 docs
 inst/doc
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: blosc
 Title: Compress and Decompress Data Using the BLOSC Library
-Version: 0.0.4.0001
+Version: 0.0.4.0002
 Authors@R: 
     person("Pepijn", "de Vries", role = c("aut", "cre"),
       email = "pepijn.devries@outlook.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# blosc 0.0.4.0001
+# blosc 0.0.4.0002
+
+* Some fixes to pass CRAN checks
+
+# blosc 0.0.4
 
 * Added support for date-time and delta time objects
 * Improved test coverage

--- a/R/compress.R
+++ b/R/compress.R
@@ -8,7 +8,7 @@
 #' In case of `blosc_compress()`, `x` should either be `raw` data or a
 #' `vector` of data to be compressed. In the latter case, you need to specify
 #' `dtype` (see `r_to_dtype()`) in order to convert the data to `raw` information
-#' first. See `vignette("blosc")` for more details.
+#' first. See `vignette("blosc-compression")` for more details.
 #' @param compressor The compression algorithm to be used. Can be any of
 #' `"blosclz"`, `"lz4"`, `"lz4hc"`, `"zlib"`, or `"zstd"`.
 #' @param level An `integer` indicating the required level of compression.

--- a/man/blosc.Rd
+++ b/man/blosc.Rd
@@ -24,7 +24,7 @@ to a specific data type.
 In case of \code{blosc_compress()}, \code{x} should either be \code{raw} data or a
 \code{vector} of data to be compressed. In the latter case, you need to specify
 \code{dtype} (see \code{r_to_dtype()}) in order to convert the data to \code{raw} information
-first. See \code{vignette("blosc")} for more details.}
+first. See \code{vignette("blosc-compression")} for more details.}
 
 \item{compressor}{The compression algorithm to be used. Can be any of
 \code{"blosclz"}, \code{"lz4"}, \code{"lz4hc"}, \code{"zlib"}, or \code{"zstd"}.}

--- a/tests/testthat/test_encode.R
+++ b/tests/testthat/test_encode.R
@@ -4,7 +4,7 @@ test_that("Encoding works as expected", {
   expect_true({
     result <- FALSE
     for (i in 1:nrow(data_types)) {
-        result <- result || !(
+      result <- result || !(
         all(
           r_to_dtype(data_types$r_representation[[i]],
                      data_types$dtype[[i]], na = -1) ==

--- a/vignettes/blosc-compression.Rmd
+++ b/vignettes/blosc-compression.Rmd
@@ -2,7 +2,7 @@
 title: "Blosc Compression"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Blosc-compression}
+  %\VignetteIndexEntry{Blosc Compression}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
No need for protect in na_check

relocate protection

ultimate UBSAN fix

reset dtype code

reset old code

UNPROTECT na_value later

remove protection before warning...

always return false

set warn_na

not when ignore is set

if

missing parenthesis

comparison

Added bitmask

Let's step by step check what triggers the UBSAN response

added missing parenthesis

fix potential aligment error

Star working with na

fixed problems

No NA actions in convert routine

fix minor ubsan warnings

disabled examples

disable r-chunks in compress vignette as well

Skip convert step for debugging

test boolean conversion only

remove test for debugging purposes

returning dummy value

added dtype_to_r to vignette for debugging

Vignette r chunks disabled

Commenting out "|b1"

Fix typo

Added protection around all Rf_coerceVector calls

store bool as int8_t to avoid alignment problems

more explicit casting

Explicit casts to avoid undefined behaviour

evrything except boolean

enabled all except boolean

enabled line that is simular to that in example

all r-lines disabled

More lines disabled

Disable suspected line

Added again but set most chunks to 'do not evaluate'

remove problematic vignette

Disable all R code in the problematic vignette

disable all R-chunks in vignette

Don't evaluate dtype r-chunks for debugging purposes

debugging memcpy

Another attempt to fix UBSAN warnings